### PR TITLE
feat: remove des-cbc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Cipher is the first constructor argument. Supported cipher methods are:
 
 Cipher             | IV
 ------------------ | ---
-`des-cbc`          | yes
 `aes-128-cbc`      | yes
 `aes-192-cbc`      | yes
 `aes-256-cbc`      | yes

--- a/lib/Cryptomute/Cryptomute.php
+++ b/lib/Cryptomute/Cryptomute.php
@@ -25,7 +25,6 @@ class Cryptomute
      * @var array
      */
     public static array $allowedCiphers = [
-        'des-cbc' => ['iv' => true, 'length' => 64],
         'aes-128-cbc' => ['iv' => true, 'length' => 128],
         'aes-192-cbc' => ['iv' => true, 'length' => 192],
         'aes-256-cbc' => ['iv' => true, 'length' => 256],

--- a/tests/CryptomuteTest.php
+++ b/tests/CryptomuteTest.php
@@ -12,7 +12,6 @@ class CryptomuteTest extends TestCase
     public const MAX_VALUE = '9999999999';
     public const TEST_REPEATS = 15;
     public static array $testedCiphers = [
-        'des-cbc' => true,
         'aes-128-cbc' => true,
         'aes-192-cbc' => true,
         'aes-256-cbc' => true,


### PR DESCRIPTION
BREAKING CHANGE

`des-cbc` cipher is removed, it's recommended to use `aes` or `camellia`

Signed-off-by: Teakowa <27560638+Teakowa@users.noreply.github.com>